### PR TITLE
- Armé la tabla acciones para guardar likes de usuarios por Pokémon.

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -24,6 +24,7 @@
       },
       "devDependencies": {
         "@types/bcrypt": "^6.0.0",
+        "@types/cookie-parser": "^1.4.9",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.3",
         "@types/jsonwebtoken": "^9.0.10",
@@ -388,6 +389,15 @@
       "license": "MIT",
       "dependencies": {
         "@types/node": "*"
+      }
+    },
+    "node_modules/@types/cookie-parser": {
+      "version": "1.4.9",
+      "resolved": "https://registry.npmjs.org/@types/cookie-parser/-/cookie-parser-1.4.9.tgz",
+      "integrity": "sha512-tGZiZ2Gtc4m3wIdLkZ8mkj1T6CEHb35+VApbL2T14Dew8HA7c+04dmKqsKRNC+8RJPm16JEK0tFSwdZqubfc4g==",
+      "dev": true,
+      "peerDependencies": {
+        "@types/express": "*"
       }
     },
     "node_modules/@types/cors": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -32,6 +32,7 @@
   },
   "devDependencies": {
     "@types/bcrypt": "^6.0.0",
+    "@types/cookie-parser": "^1.4.9",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.3",
     "@types/jsonwebtoken": "^9.0.10",

--- a/backend/src/adapters/types.ts
+++ b/backend/src/adapters/types.ts
@@ -1,3 +1,10 @@
+import 'express-serve-static-core';
+
+declare module 'express-serve-static-core' {
+  interface Request {
+    usuario?: { id: string; email: string; iat: number; exp: number };
+  }
+}
 export interface PokemonApiResponse {
   abilities: Ability[];
   base_experience: number;

--- a/backend/src/controllers/guardarLike.ts
+++ b/backend/src/controllers/guardarLike.ts
@@ -1,0 +1,28 @@
+import { Request, Response } from "express";
+import Pool from "../database/connecionPostgresSQL";
+
+
+export const guardarLike = async (req: Request, res: Response) => {
+    const { id_pokemon, statusPhoto } = req.body
+    const email_usuario = req.usuario?.email;
+    const fecha_actual = new Date()
+    console.log('fecha:', fecha_actual, 'id pokemon:', id_pokemon, 'estado en foto:', statusPhoto, 'email del usuario', email_usuario)
+    try {
+
+        const result = await Pool.query('SELECT id_user FROM usuarios WHERE user_email = $1', [email_usuario])
+
+        if (result.rowCount === 0) {
+            return res.status(401).json({ msg: "No se encontro el id del usuario" });
+        }
+        const id_user = result.rows[0].id_user
+        console.log(id_user)
+         await Pool.query('INSERT INTO acciones (pokemon_id, user_id, like_foto) VALUES ($1, $2, $3)', [id_pokemon,id_user,statusPhoto])
+        res.status(200).json({ ok: true })
+
+    } catch (error) {
+        console.error("Error al guardar like:", error);
+        res.status(500).json({ ok: false, msg: "Error interno del servidor" });
+    }
+
+
+}

--- a/backend/src/middleware/validacionJWT.ts
+++ b/backend/src/middleware/validacionJWT.ts
@@ -15,8 +15,9 @@ export const validarJwt = (req: Request, res: Response, next:NextFunction) => {
         if(!secreto){
             throw new Error('JWT_SECRET no definido en el .env')
         }
-        const validPayload = jwt.verify(token,secreto)
-        console.log(validPayload)
+        const validPayload = jwt.verify(token,secreto) as { id: string; email: string; iat: number; exp: number };
+        req.usuario = validPayload;
+       console.log('Email del usuario:', req.usuario.email);
         next()
     } catch (error) {
         res.status(400).json({ok: false, message: 'token invalido', error})

--- a/backend/src/routers/useRouters.ts
+++ b/backend/src/routers/useRouters.ts
@@ -5,12 +5,16 @@ import { Login } from "../controllers/login";
 import { body} from "express-validator";
 import { validarCampos } from "../middleware/validacionDeCampos";
 import { crear } from "../controllers/crearUsers";
+import { guardarLike } from "../controllers/guardarLike";
 
 import { filtersDb } from "../controllers/filters";
+import { validarJwt } from "../middleware/validacionJWT";
+import cookieParser from 'cookie-parser';
+
 
 
 const router = express.Router();
-
+router.use(cookieParser());
 router.get('/pokemones' ,getPokemones);
 
 router.post('/login-user', [
@@ -34,6 +38,8 @@ router.post('/crear-user', [
         validarCampos
 ],
 crear)
+
+router.put('/like-pokemon', validarJwt, guardarLike)
 router.get(`/pokemones/generation/:selectedGeneration`, filtersDb);
 
 export default router;

--- a/frontend/src/components/botonLike.tsx
+++ b/frontend/src/components/botonLike.tsx
@@ -1,16 +1,19 @@
-import { useState, useEffect, useCallback } from "react";
+import { useState, useCallback } from "react";
 
 const Like = () => {
     const [likePhoto, setLike] = useState<boolean>(false)
 
-    const updateLike = useCallback(async () => {
+    const updateLike = useCallback(async (nuevoValor: boolean) => {
         try {
             const respuesta = await fetch('http://localhost:3000/like-pokemon', {
-                method: 'POST',
+                method: 'PUT',
                 headers: {
                     'Content-Type': 'application/json'
                 },
-                body: JSON.stringify({ statusPhoto: likePhoto }),
+                body: JSON.stringify({ 
+                    statusPhoto: nuevoValor,
+                    id_pokemon:2
+                 }),
                 credentials:'include',
             })
             const resultado = await  respuesta.json();
@@ -20,16 +23,18 @@ const Like = () => {
         } catch (error) {
             console.error("Error al actualizar like:", error);
         }
-    }, [likePhoto])
+    }, [])
+     const handleLike = () => {
+        const nuevoValor = !likePhoto;
+        setLike(nuevoValor)
+        updateLike(nuevoValor)
+     }
 
-
-    useEffect(() => {
-        updateLike()
-    }, [updateLike])
+   
 
     return (
         <>
-            <button className="focus:outline-none" onClick={() => setLike(!likePhoto)}>
+            <button className="focus:outline-none" onClick={handleLike}>
                 {likePhoto ? (
                     <svg
                         xmlns="http://www.w3.org/2000/svg"

--- a/frontend/src/components/tarjetaPokemon.tsx
+++ b/frontend/src/components/tarjetaPokemon.tsx
@@ -12,6 +12,7 @@ function Tarjeta({ name, ability, img ,description ,attacks,generation}: Pokemon
   
 
  const [showDescription, setShowDescription] = useState<boolean>(false);
+ 
   return (
     // <div className="grid grid-cols-3 grid-rows-2 gap-2 w-full">
     <div className='  flex justify-center items-center bg-white rounded-lg shadow-md  w-[200px]'>


### PR DESCRIPTION
- Endpoint /like-pokemon permite guardar likes (todavía no actualiza ni recarga la página).
- Uso JWT para obtener el email del usuario y asociarlo al like.
- Guardo timestamp automáticamente al crear.
- Middleware de JWT agrega req.usuario para acceder al email del usuario.